### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A WebGL/Three.js implementaiton of a quadtree planet.
   * `proceduralLandscape.html`    - (SOON) A procedural landscape generated in real time.
 	
 * `src/`                          - The main source files for the project.
-  * `worker/`                     - The worker and it's componants that perform the quadtree work.
+  * `worker/`                     - The worker and it's components that perform the quadtree work.
 
 * `bin/`                          - The output directory for the build script.
 


### PR DESCRIPTION
@merpnderp, I've corrected a typographical error in the documentation of the [webglquadtreeplanet](https://github.com/merpnderp/webglquadtreeplanet) project. Specifically, I've changed componant to component. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
